### PR TITLE
No *need* for typedef when using enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### C
 
-In C, enumerations are really just a wrapper for named integer constants.  They are defined with the keyword `enum`, although to be fully useful they need to also be defined as a `typedef`.  For example:
+In C, enumerations are really just a wrapper for named integer constants.  They are defined with the keyword `enum`, often in combination with `typedef`.  For example:
 
 ```c
 #include<stdio.h>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### C
 
-In C, enumerations are really just a wrapper for named integer constants.  They are defined with the keyword `enum`, often in combination with `typedef`.  For example:
+In C, enumerations are really just a wrapper for named integer constants.  They are defined with the keyword `enum`, usually in combination with `typedef`.  For example:
 
 ```c
 #include<stdio.h>


### PR DESCRIPTION
You can also refer to it as `enum EnumName`.